### PR TITLE
Fix issue https://github.com/bubibubi/sqliteef6migrations/issues/6

### DIFF
--- a/System.Data.SQLite.EF6.Migrations/LiteralHelpers.cs
+++ b/System.Data.SQLite.EF6.Migrations/LiteralHelpers.cs
@@ -73,6 +73,26 @@ namespace System.Data.SQLite.EF6.Migrations
         }
 
 
+		/// <summary>
+		/// Return the string value in <paramref name="tableName"/> without the "dbo." starting part.
+		/// </summary>
+		/// <param name="tableName">
+		/// If the value is null or whitespace, the input value will be returned
+		/// </param>
+		/// <returns></returns>
+		public static string ReturnTableNameWithoutStartingDbo(string tableName)
+		{
+			if (string.IsNullOrWhiteSpace(tableName))
+				return tableName;
+			else
+			{
+				if (tableName.ToLower().StartsWith("dbo.") && tableName.Length > 4)
+					return tableName.Substring(4);
+				else return tableName;
+			}
+		}
+
+
 
 
     }

--- a/System.Data.SQLite.EF6.Migrations/SQLiteMigrationSqlGenerator.cs
+++ b/System.Data.SQLite.EF6.Migrations/SQLiteMigrationSqlGenerator.cs
@@ -307,7 +307,7 @@ namespace System.Data.SQLite.EF6.Migrations
             if (migrationOperation.IsUnique)
                 ddlBuilder.AppendSql("UNIQUE ");
             ddlBuilder.AppendSql("INDEX ");
-            ddlBuilder.AppendIdentifier(migrationOperation.Name);
+			ddlBuilder.AppendIdentifier(GenerateQualifiedOperationAndTableName(migrationOperation.Name, migrationOperation.Table));
             ddlBuilder.AppendSql(" ON ");
             ddlBuilder.AppendIdentifier(migrationOperation.Table);
             ddlBuilder.AppendSql(" (");
@@ -316,6 +316,11 @@ namespace System.Data.SQLite.EF6.Migrations
 
             return ddlBuilder.GetCommandText();
         }
+
+		private static string GenerateQualifiedOperationAndTableName(string operationName, string tableName)
+		{
+			return string.Format("{0}_{1}", operationName, LiteralHelpers.ReturnTableNameWithoutStartingDbo(tableName));
+		}
 
         #endregion
 
@@ -346,7 +351,8 @@ namespace System.Data.SQLite.EF6.Migrations
         {
             SQLiteDdlBuilder ddlBuilder = new SQLiteDdlBuilder();
             ddlBuilder.AppendSql("DROP INDEX ");
-            ddlBuilder.AppendIdentifier(migrationOperation.Name);
+			//ddlBuilder.AppendIdentifier(migrationOperation.Name);
+			ddlBuilder.AppendIdentifier(GenerateQualifiedOperationAndTableName(migrationOperation.Name, migrationOperation.Table));
             ddlBuilder.AppendSql(" ON ");
             ddlBuilder.AppendIdentifier(migrationOperation.Table);
             return ddlBuilder.GetCommandText();


### PR DESCRIPTION
In methods GenerateSqlStatementConcrete(...) for 'CREATE INDEX' and 'DROP INDEX' the identifier was 'fully qualified' by adding table name.

The method 'GenerateQualifiedOperationAndTableName(..)' add the fully qualifying part: the table name.

Added also a LiteralHelper method to return table name without starting 'dbo'