### PR TITLE
Add support for more data types when adding a new column with default value

### DIFF
--- a/System.Data.SQLite.EF6.Migrations/SQLiteMigrationSqlGenerator.cs
+++ b/System.Data.SQLite.EF6.Migrations/SQLiteMigrationSqlGenerator.cs
@@ -196,6 +196,26 @@ namespace System.Data.SQLite.EF6.Migrations
                     if (defaultValue.Kind == DateTimeKind.Utc) format += 'Z';
                     ddlBuilder.AppendSql($" DEFAULT '{defaultValue.ToString(format)}'");
                 }
+                else if (column.DefaultValue is bool boolValue)
+                {
+                    ddlBuilder.AppendSql($" DEFAULT {(boolValue ? 1 : 0)}");
+                }
+                else if (column.DefaultValue is string stringValue)
+                {
+                    ddlBuilder.AppendSql($" DEFAULT '{stringValue}'");
+                }
+                else if (column.DefaultValue is Guid guidValue)
+                {
+                    ddlBuilder.AppendSql($" DEFAULT '{guidValue}'");
+                }
+                else if (column.DefaultValue.GetType().IsEnum)
+                {
+                    ddlBuilder.AppendSql($" DEFAULT {(int)column.DefaultValue}");
+                }
+                else if (column.DefaultValue.GetType().IsValueType)
+                {
+                    ddlBuilder.AppendSql($" DEFAULT {column.DefaultValue}");
+                }
             }
             ddlBuilder.AppendNewLine();
 


### PR DESCRIPTION
When I tried to add a new column with a default value, the default value was not included in the SQL statement. For example,

```
public override void Up()
{
    AddColumn("dbo.TestTable", "ExtraColumn", c => c.Int(nullable: false, defaultValue: 1));
}
```
The generated SQL would be "ALTER TABLE "TestTable" ADD COLUMN "ExtraColumn"int not null"
If the table already has some data in it, there would be an error during migration: "Cannot add a NOT NULL column with default value NULL"

This pull request adds support for more data types for the default value other than DateTime.
